### PR TITLE
Using the correct options to fallback to default harmonic set in the song's options

### DIFF
--- a/lib/muse.rb
+++ b/lib/muse.rb
@@ -152,7 +152,7 @@ module Muse
         end
         options[:bpm] = options[:bpm] || @bpm || 120
         options[:envelope] = options[:envelope] || @envelope || 'default'
-        options[:harmonic] = options[:harmonic] || @harmonic || 'default'
+        options[:h] = options[:h] || @harmonic || 'default'
         @bars[id] << Bar.new(id, options)
         @bars[id].last
       end


### PR DESCRIPTION
The song's default harmonic set while creating a song object was not being used. Fixed that by using the correct symbol.